### PR TITLE
Add --no-cache flag to deploy command

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -7,6 +7,7 @@ import {request, readEventSource} from '../auth-request.js'
 interface DeployRequest {
   commit?: string
   discoFile?: string
+  noCache?: boolean
 }
 
 export interface DeployResponse {
@@ -29,6 +30,7 @@ export default class Deploy extends Command {
     // TODO file seems to not work right now - re-test once daemon is fixed?
     file: Flags.string({required: false}),
     disco: Flags.string({required: false}),
+    'no-cache': Flags.boolean({required: false, default: false, description: 'Build without using Docker cache'}),
   }
 
   public async run(): Promise<void> {
@@ -44,6 +46,10 @@ export default class Deploy extends Command {
 
     if (discoFile) {
       reqBody.discoFile = discoFile
+    }
+
+    if (flags['no-cache']) {
+      reqBody.noCache = true
     }
 
     const res = await request({method: 'POST', url, body: reqBody, discoConfig, expectedStatuses: [201]})


### PR DESCRIPTION
## Summary

- Adds `--no-cache` boolean flag to the `deploy` command
- Sends `noCache: true` in the POST request body to the daemon API when set

## Usage

```bash
disco deploy --project mysite --no-cache
```

## Companion PR

Daemon side: https://github.com/letsdiscodev/disco-daemon/pull/93

## Files changed

| File | Change |
|------|--------|
| `src/commands/deploy.ts` | Add `--no-cache` flag, `noCache` to request interface and body |

## Test plan

- [ ] `disco deploy --project <name>` — works as before (no `noCache` in body)
- [ ] `disco deploy --project <name> --no-cache` — sends `noCache: true` in request body
- [ ] `disco deploy --help` — shows `--no-cache` flag in help output